### PR TITLE
Fix Django 3.2 version range in tox file

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ setenv =
     PYTHONDONTWRITEBYTECODE=1
 deps =
     coverage==7.3.2
-    dj32: django>=3.1,<3.2
+    dj32: django>=3.2,<3.3
     dj41: django>=4.1,<4.2
     dj42: django>=4.2,<4.3
     djmain: https://github.com/django/django/archive/main.tar.gz


### PR DESCRIPTION
Just noticed that the version for Django 3.2 in the tox file is actually testing for Django 3.1.